### PR TITLE
improvement /mute(related Issue #12)

### DIFF
--- a/bot/telebot.py
+++ b/bot/telebot.py
@@ -550,17 +550,17 @@ dispatcher.add_handler(mute_handler)
 ##mute support func
 def mute_parse_date(message_text):
         hour=int()
-        if len(re.findall(" [0-9]{1,3}h ", message_text)):
+        if any(re.findall(" [0-9]{1,3}h ", message_text)):
                 temp = re.findall(" [0-9]{1,2}h ", message_text)
                 hour = int(re.sub("h", "", temp[0]))
         day=int()
-        if len(re.findall(" [0-9]{1,3}d ", message_text)):
+        if any(re.findall(" [0-9]{1,3}d ", message_text)):
                 temp = re.findall(" [0-9]{1,2}d ", message_text)
                 day = int(re.sub("d", "", temp[0]))
-        if len(re.findall(" [0-9]{1,3}w ", message_text)):
+        if any(re.findall(" [0-9]{1,3}w ", message_text)):
                 temp = re.findall(" [0-9]{1,2}w ", message_text)
                 day = day + int(re.sub("w", "", temp[0])) * 7
-        if len(re.findall(" inf ", message_text)):
+        if any(re.findall(" inf ", message_text)):
                 day = 367
         return hour, day
 
@@ -572,7 +572,8 @@ def mute_gen_duration_message(hour, day):
                 else:
                         duration = str(hour) + " hours"
         if day>0:
-                if hour>0: duration = duration + " "
+                if hour>0:
+                        duration = duration + " "
                 if day==1:
                         duration = duration + str(day) + " day"
                 else:
@@ -583,15 +584,15 @@ def mute_gen_duration_message(hour, day):
 
 def mute_parse_comment_message(message_text):
         comment = message_text.replace("/mute ", "")
-        if len(re.findall(" [0-9]{1,3}h ", message_text)):
+        if any(re.findall(" [0-9]{1,3}h ", message_text)):
                 comment = re.sub("[0-9]{1,3}h ", "", comment)
-        if len(re.findall(" [0-9]{1,3}d ", message_text)):
+        if any(re.findall(" [0-9]{1,3}d ", message_text)):
                 comment = re.sub("[0-9]{1,3}d ", "", comment)
-        if len(re.findall(" [0-9]{1,3}w ", message_text)):
+        if any(re.findall(" [0-9]{1,3}w ", message_text)):
                 comment = re.sub("[0-9]{1,3}w ", "", comment)
-        if len(re.findall(" inf ", message_text)):
+        if any(re.findall(" inf ", message_text)):
                 comment = re.sub("inf ", "", comment)
-        if len(re.findall("[a-zA-Z0-9]", comment))==0:
+        if any(re.findall("[a-zA-Z0-9]", comment))==0:
                 comment = "not found"
         return comment
 

--- a/bot/telebot.py
+++ b/bot/telebot.py
@@ -510,18 +510,18 @@ def mute(update, context):
         first_name = re.sub("[*]", "\*", first_name)
         first_name = re.sub("[`]", "\`", first_name)
         first_name = re.sub("[[]", "\[", first_name)
-        message_text=update.message.text
+        message_text=update.message.text+" "
         hour=int()
-        if len(re.findall(" [0-9]{1,3}h", message_text)):
-                temp = re.findall(" [0-9]{1,2}h", message_text)
+        if len(re.findall(" [0-9]{1,3}h ", message_text)):
+                temp = re.findall(" [0-9]{1,2}h ", message_text)
                 hour = int(re.sub("h", "", temp[0]))
         day=int()
-        if len(re.findall(" [0-9]{1,3}d", message_text)):
-                temp = re.findall(" [0-9]{1,2}d", message_text)
+        if len(re.findall(" [0-9]{1,3}d ", message_text)):
+                temp = re.findall(" [0-9]{1,2}d ", message_text)
                 day = int(re.sub("d", "", temp[0]))
         week=int()
         if len(re.findall(" [0-9]{1,3}w ", message_text)):
-                temp = re.findall(" [0-9]{1,2}w", message_text)
+                temp = re.findall(" [0-9]{1,2}w ", message_text)
                 week = int(re.sub("w", "", temp[0]))
         if len(re.findall(" inf", message_text)):
                 day=367

--- a/bot/telebot.py
+++ b/bot/telebot.py
@@ -505,28 +505,39 @@ def mute(update, context):
         command_name = inspect.currentframe().f_code.co_name
         feature_flag = config.get(section, command_name) == 'on'
         admins = update.message.from_user.id in get_admin_ids(context, update.message.chat_id)
-        date = int()
+        user_id = update.message.reply_to_message.from_user.id
+        first_name = re.sub("[_]", "\_", update.message.reply_to_message.from_user.first_name)
+        first_name = re.sub("[*]", "\*", first_name)
+        first_name = re.sub("[`]", "\`", first_name)
+        first_name = re.sub("[[]", "\[", first_name)
+        message_text=update.message.text
+        hour=int()
+        if len(re.findall(" [0-9]{1,3}h ", message_text)):
+                temp = re.findall(" [0-9]{1,2}h ", message_text)
+                hour = int(re.sub("h", "", temp[0]))
+        day=int()
+        if len(re.findall(" [0-9]{1,3}d ", message_text)):
+                temp = re.findall(" [0-9]{1,2}d ", message_text)
+                day = int(re.sub("d", "", temp[0]))
+        week=int()
+        if len(re.findall(" [0-9]{1,3}w ", message_text)):
+                temp = re.findall(" [0-9]{1,2}w ", message_text)
+                week = int(re.sub("w", "", temp[0]))
+        if len(re.findall(" inf ", message_text)):
+                day=367
         restrict = ChatPermissions(can_send_messages=False, can_send_media_messages=False, can_send_other_messages=False, can_add_web_page_previews=False)
         if in_section and feature_flag and admins:
                 try:
-                        if len(sys.argv) < 1:
-                                date = int(' '.join(context.args))
-                        else:
-                                date = int(1)
                         context.bot.restrict_chat_member(chat_id=update.message.chat_id, user_id=update.message.reply_to_message.from_user.id, \
-                                until_date=datetime.datetime.now() + datetime.timedelta(days=date), permissions = restrict)
-                        context.bot.send_message(chat_id=update.message.chat_id, text="User " + "@" + str(update.message.reply_to_message.from_user.username) + " banned.", \
+                                until_date=datetime.datetime.now() + datetime.timedelta(days=day, hours=hour, weeks=week), permissions = restrict)
+                        context.bot.send_message(chat_id=update.message.chat_id, text="User " + "@" + str(update.message.reply_to_message.from_user.username) + " muted.", \
                                 reply_to_message_id=update.message.message_id)
                         context.bot.deleteMessage(chat_id=update.message.chat.id, message_id=update.message.message_id)
                 except TypeError:
-                        if len(sys.argv) < 1:
-                                date = int(' '.join(context.args))
-                        else:
-                                date = int(1)
                         context.bot.restrict_chat_member(chat_id=update.message.chat_id, user_id=update.message.reply_to_message.from_user.id, \
                                 until_date=datetime.datetime.now() + datetime.timedelta(days=date), permissions = restrict)
-                        context.bot.send_message(chat_id=update.message.chat_id, text="User" + " banned", \
-                                reply_to_message_id=update.message.message_id)
+                        context.bot.send_message(chat_id=update.message.chat_id, text="User " + "[" + first_name + "](tg://user?id=" + user_id + ")" + " muted", \
+                                reply_to_message_id=update.message.message_id, parse_mode='Markdown')
                         context.bot.deleteMessage(chat_id=update.message.chat.id, message_id=update.message.message_id)
 
 mute_handler = CommandHandler('mute', mute, pass_args=True, run_async=True)

--- a/bot/telebot.py
+++ b/bot/telebot.py
@@ -535,7 +535,7 @@ def mute(update, context):
                         context.bot.deleteMessage(chat_id=update.message.chat.id, message_id=update.message.message_id)
                 except TypeError:
                         context.bot.restrict_chat_member(chat_id=update.message.chat_id, user_id=update.message.reply_to_message.from_user.id, \
-                                until_date=datetime.datetime.now() + datetime.timedelta(days=date), permissions = restrict)
+                                until_date=datetime.datetime.now() + datetime.timedelta(days=day, hours=hour, weeks=week), permissions = restrict)
                         context.bot.send_message(chat_id=update.message.chat_id, text="User " + "[" + first_name + "](tg://user?id=" + user_id + ")" + " muted", \
                                 reply_to_message_id=update.message.message_id, parse_mode='Markdown')
                         context.bot.deleteMessage(chat_id=update.message.chat.id, message_id=update.message.message_id)

--- a/bot/telebot.py
+++ b/bot/telebot.py
@@ -512,18 +512,18 @@ def mute(update, context):
         first_name = re.sub("[[]", "\[", first_name)
         message_text=update.message.text
         hour=int()
-        if len(re.findall(" [0-9]{1,3}h ", message_text)):
-                temp = re.findall(" [0-9]{1,2}h ", message_text)
+        if len(re.findall(" [0-9]{1,3}h", message_text)):
+                temp = re.findall(" [0-9]{1,2}h", message_text)
                 hour = int(re.sub("h", "", temp[0]))
         day=int()
-        if len(re.findall(" [0-9]{1,3}d ", message_text)):
-                temp = re.findall(" [0-9]{1,2}d ", message_text)
+        if len(re.findall(" [0-9]{1,3}d", message_text)):
+                temp = re.findall(" [0-9]{1,2}d", message_text)
                 day = int(re.sub("d", "", temp[0]))
         week=int()
         if len(re.findall(" [0-9]{1,3}w ", message_text)):
-                temp = re.findall(" [0-9]{1,2}w ", message_text)
+                temp = re.findall(" [0-9]{1,2}w", message_text)
                 week = int(re.sub("w", "", temp[0]))
-        if len(re.findall(" inf ", message_text)):
+        if len(re.findall(" inf", message_text)):
                 day=367
         restrict = ChatPermissions(can_send_messages=False, can_send_media_messages=False, can_send_other_messages=False, can_add_web_page_previews=False)
         if in_section and feature_flag and admins:

--- a/bot/telebot.py
+++ b/bot/telebot.py
@@ -516,7 +516,7 @@ def mute(update, context):
                 last_name = re.sub("[*]", "\*", last_name)
                 last_name = re.sub("[`]", "\`", last_name)
                 last_name = re.sub("[[]", "\[", last_name)
-                full_name = first_name + " " last_name
+                full_name = first_name + " " + last_name
         except TypeError:
                 full_name = first_name
         message_text=update.message.text+" "

--- a/bot/telebot.py
+++ b/bot/telebot.py
@@ -516,7 +516,9 @@ def mute(update, context):
         last_name = re.sub("[`]", "\`", last_name)
         last_name = re.sub("[[]", "\[", last_name)
         message_text=update.message.text+" "
-        hour,day,duration,comment = mute_parse(message_text)
+        hour,day = mute_parse_date(message_text)
+        duration = mute_gen_duration_message(hour, day)
+        comment = mute_parse_comment_message(message_text)
         restrict = ChatPermissions(can_send_messages=False, can_send_media_messages=False, can_send_other_messages=False, can_add_web_page_previews=False)
         if in_section and feature_flag and admins:
                 try:
@@ -542,7 +544,7 @@ mute_handler = CommandHandler('mute', mute, pass_args=True, run_async=True)
 dispatcher.add_handler(mute_handler)
 
 ##mute support func
-def mute_parse(message_text):
+def mute_parse_date(message_text):
         hour=int()
         if len(re.findall(" [0-9]{1,3}h ", message_text)):
                 temp = re.findall(" [0-9]{1,2}h ", message_text)
@@ -556,19 +558,26 @@ def mute_parse(message_text):
                 day = day + int(re.sub("w", "", temp[0])) * 7
         if len(re.findall(" inf ", message_text)):
                 day = 367
+        return hour, day
+
+def mute_gen_duration_message(hour, day):
+        duration=str()
         if hour>0:
                 if hour==1:
-                        duration = str(hour) + "hour"
+                        duration = str(hour) + " hour"
                 else:
-                        duration = str(hour) + "hours"
+                        duration = str(hour) + " hours"
         if day>0:
                 if hour>0: duration = duration + " "
                 if day==1:
-                        duration = str(day) + "day"
+                        duration = duration + str(day) + " day"
                 else:
-                        duration = str(day) + "days"
+                        duration = duration + str(day) + " days"
         if hour==0 and day==0 or day>366:
                 duration = "forever"
+        return duration
+
+def mute_parse_comment_message(message_text):
         comment = message_text.replace("/mute ", "")
         if len(re.findall(" [0-9]{1,3}h ", message_text)):
                 comment = re.sub("[0-9]{1,3}h ", "", comment)
@@ -580,7 +589,7 @@ def mute_parse(message_text):
                 comment = re.sub("inf ", "", comment)
         if len(re.findall("[a-zA-Z0-9]", comment))==0:
                 comment = "not found"
-        return hour, day, duration, comment
+        return comment
 
 
 ## Warn some user

--- a/bot/telebot.py
+++ b/bot/telebot.py
@@ -511,10 +511,14 @@ def mute(update, context):
         first_name = re.sub("[*]", "\*", first_name)
         first_name = re.sub("[`]", "\`", first_name)
         first_name = re.sub("[[]", "\[", first_name)
-        last_name = re.sub("[_]", "\_", update.message.reply_to_message.from_user.last_name)
-        last_name = re.sub("[*]", "\*", last_name)
-        last_name = re.sub("[`]", "\`", last_name)
-        last_name = re.sub("[[]", "\[", last_name)
+        try:
+                last_name = re.sub("[_]", "\_", update.message.reply_to_message.from_user.last_name)
+                last_name = re.sub("[*]", "\*", last_name)
+                last_name = re.sub("[`]", "\`", last_name)
+                last_name = re.sub("[[]", "\[", last_name)
+                full_name = first_name + " " last_name
+        except TypeError:
+                full_name = first_name
         message_text=update.message.text+" "
         hour,day = mute_parse_date(message_text)
         duration = mute_gen_duration_message(hour, day)
@@ -524,7 +528,7 @@ def mute(update, context):
                 try:
                         context.bot.restrict_chat_member(chat_id=update.message.chat_id, user_id=update.message.reply_to_message.from_user.id, \
                                 until_date=datetime.datetime.now() + datetime.timedelta(days=day, hours=hour), permissions = restrict)
-                        context.bot.send_message(chat_id=admin_chat, text="User " + "[" + first_name + " " + last_name + "](tg://user?id=" + str(user_id) + ") " \
+                        context.bot.send_message(chat_id=admin_chat, text="User " + "[" + full_name + "](tg://user?id=" + str(user_id) + ") " \
                                 + "(@" + update.message.reply_to_message.from_user.username + ") was muted by [admin](tg://user?id=" + str(update.message.from_user.id) + ") " \
                                 + "in chat " + update.message.chat.title + "\nDuration: " + duration + "\nComment: " + comment, parse_mode='Markdown')
                         context.bot.send_message(chat_id=update.message.chat_id, text="User " + "@" + str(update.message.reply_to_message.from_user.username) + " muted.", \
@@ -533,7 +537,7 @@ def mute(update, context):
                 except TypeError:
                         context.bot.restrict_chat_member(chat_id=update.message.chat_id, user_id=update.message.reply_to_message.from_user.id, \
                                 until_date=datetime.datetime.now() + datetime.timedelta(days=day, hours=hour), permissions = restrict)
-                        context.bot.send_message(chat_id=admin_chat, text="User " + "[" + first_name + " " + last_name + "](tg://user?id=" + str(user_id) + ") " \
+                        context.bot.send_message(chat_id=admin_chat, text="User " + "[" + full_name + "](tg://user?id=" + str(user_id) + ") " \
                                 + "was muted by [admin](tg://user?id=" + str(update.message.from_user.id) + ") " + "in chat " + update.message.chat.title \
                                 + "\nDuration: " + duration + "\nComment: " + comment, parse_mode='Markdown')
                         context.bot.send_message(chat_id=update.message.chat_id, text="User " + "[" + first_name + "](tg://user?id=" + str(user_id) + ")" + " muted", \

--- a/bot/telebot.py
+++ b/bot/telebot.py
@@ -516,6 +516,33 @@ def mute(update, context):
         last_name = re.sub("[`]", "\`", last_name)
         last_name = re.sub("[[]", "\[", last_name)
         message_text=update.message.text+" "
+        hour,day,duration,comment = mute_parse(message_text)
+        restrict = ChatPermissions(can_send_messages=False, can_send_media_messages=False, can_send_other_messages=False, can_add_web_page_previews=False)
+        if in_section and feature_flag and admins:
+                try:
+                        context.bot.restrict_chat_member(chat_id=update.message.chat_id, user_id=update.message.reply_to_message.from_user.id, \
+                                until_date=datetime.datetime.now() + datetime.timedelta(days=day, hours=hour), permissions = restrict)
+                        context.bot.send_message(chat_id=admin_chat, text="User " + "[" + first_name + " " + last_name + "](tg://user?id=" + str(user_id) + ") " \
+                                + "(@" + update.message.reply_to_message.from_user.username + ") was muted by [admin](tg://user?id=" + str(update.message.from_user.id) + ") " \
+                                + "in chat " + update.message.chat.title + "\nDuration: " + duration + "\nComment: " + comment, parse_mode='Markdown')
+                        context.bot.send_message(chat_id=update.message.chat_id, text="User " + "@" + str(update.message.reply_to_message.from_user.username) + " muted.", \
+                                reply_to_message_id=update.message.message_id)
+                        context.bot.deleteMessage(chat_id=update.message.chat.id, message_id=update.message.message_id)
+                except TypeError:
+                        context.bot.restrict_chat_member(chat_id=update.message.chat_id, user_id=update.message.reply_to_message.from_user.id, \
+                                until_date=datetime.datetime.now() + datetime.timedelta(days=day, hours=hour), permissions = restrict)
+                        context.bot.send_message(chat_id=admin_chat, text="User " + "[" + first_name + " " + last_name + "](tg://user?id=" + str(user_id) + ") " \
+                                + "was muted by [admin](tg://user?id=" + str(update.message.from_user.id) + ") " + "in chat " + update.message.chat.title \
+                                + "\nDuration: " + duration + "\nComment: " + comment, parse_mode='Markdown')
+                        context.bot.send_message(chat_id=update.message.chat_id, text="User " + "[" + first_name + "](tg://user?id=" + str(user_id) + ")" + " muted", \
+                                reply_to_message_id=update.message.message_id, parse_mode='Markdown')
+                        context.bot.deleteMessage(chat_id=update.message.chat.id, message_id=update.message.message_id)
+
+mute_handler = CommandHandler('mute', mute, pass_args=True, run_async=True)
+dispatcher.add_handler(mute_handler)
+
+##mute support func
+def mute_parse(message_text):
         hour=int()
         if len(re.findall(" [0-9]{1,3}h ", message_text)):
                 temp = re.findall(" [0-9]{1,2}h ", message_text)
@@ -553,29 +580,8 @@ def mute(update, context):
                 comment = re.sub("inf ", "", comment)
         if len(re.findall("[a-zA-Z0-9]", comment))==0:
                 comment = "not found"
-        restrict = ChatPermissions(can_send_messages=False, can_send_media_messages=False, can_send_other_messages=False, can_add_web_page_previews=False)
-        if in_section and feature_flag and admins:
-                try:
-                        context.bot.restrict_chat_member(chat_id=update.message.chat_id, user_id=update.message.reply_to_message.from_user.id, \
-                                until_date=datetime.datetime.now() + datetime.timedelta(days=day, hours=hour), permissions = restrict)
-                        context.bot.send_message(chat_id=admin_chat, text="User " + "[" + first_name + " " + last_name + "](tg://user?id=" + str(user_id) + ") " \
-                                + "(@" + update.message.reply_to_message.from_user.username + ") was muted by [admin](tg://user?id=" + str(update.message.from_user.id) + ") " \
-                                + "in chat " + update.message.chat.title + "\nDuration: " + duration + "\nComment: " + comment, parse_mode='Markdown')
-                        context.bot.send_message(chat_id=update.message.chat_id, text="User " + "@" + str(update.message.reply_to_message.from_user.username) + " muted.", \
-                                reply_to_message_id=update.message.message_id)
-                        context.bot.deleteMessage(chat_id=update.message.chat.id, message_id=update.message.message_id)
-                except TypeError:
-                        context.bot.restrict_chat_member(chat_id=update.message.chat_id, user_id=update.message.reply_to_message.from_user.id, \
-                                until_date=datetime.datetime.now() + datetime.timedelta(days=day, hours=hour), permissions = restrict)
-                        context.bot.send_message(chat_id=admin_chat, text="User " + "[" + first_name + " " + last_name + "](tg://user?id=" + str(user_id) + ") " \
-                                + "was muted by [admin](tg://user?id=" + str(update.message.from_user.id) + ") " + "in chat " + update.message.chat.title \
-                                + "\nDuration: " + duration + "\nComment: " + comment, parse_mode='Markdown')
-                        context.bot.send_message(chat_id=update.message.chat_id, text="User " + "[" + first_name + "](tg://user?id=" + str(user_id) + ")" + " muted", \
-                                reply_to_message_id=update.message.message_id, parse_mode='Markdown')
-                        context.bot.deleteMessage(chat_id=update.message.chat.id, message_id=update.message.message_id)
+        return hour, day, duration, comment
 
-mute_handler = CommandHandler('mute', mute, pass_args=True, run_async=True)
-dispatcher.add_handler(mute_handler)
 
 ## Warn some user
 def warn(update, context, args):


### PR DESCRIPTION
add functional for mute. now admins can specify duration with number and postfix `h` for hours, `d` for days, `w` for week and `inf` for forever.

for example:

command `/mute 14d` -- mute user for two week

or

command `/mute inf` or `/mute` -- indefinitely mute user