### PR TITLE
Add users activity counter in sqlite

### DIFF
--- a/bot/dbhelper.py
+++ b/bot/dbhelper.py
@@ -11,6 +11,9 @@ class DBHelper:
         stmt = "CREATE TABLE IF NOT EXISTS users (id INTEGER NOT NULL PRIMARY KEY UNIQUE,username STR NOT NULL,warn INTEGER,ban STR,message_id INTEGER)"
         self.conn.execute(stmt)
         self.conn.commit()
+        stmt = "CREATE TABLE IF NOT EXISTS usersactivity (id INTEGER NOT NULL PRIMARY KEY UNIQUE,username STR NOT NULL,messages INTEGER)"
+        self.conn.execute(stmt)
+        self.conn.commit()
 
     def add_item(self, user_id, user_username, message_id):
         stmt = "INSERT INTO users (id, username, message_id) VALUES (?, ?, ?) ON CONFLICT(id) DO UPDATE SET message_id = excluded.message_id"
@@ -48,5 +51,11 @@ class DBHelper:
     def delete_warn(self,user_id, user_username, warn):
         stmt = "INSERT INTO users (id, username, warn) VALUES (?, ?, ?) ON CONFLICT(id) DO UPDATE SET id = excluded.id,warn = 0"
         args = (user_id, user_username, warn)
+        self.conn.execute(stmt, args)
+        self.conn.commit()
+
+    def activity_user(self, user_id, user_username):
+        stmt = "INSERT INTO usersactivity (id, username, messages) VALUES (?, ?, 1) ON CONFLICT(id) DO UPDATE SET id = excluded.id, messages = messages + 1"
+        args = (user_id, user_username)
         self.conn.execute(stmt, args)
         self.conn.commit()

--- a/bot/telebot.py
+++ b/bot/telebot.py
@@ -816,6 +816,21 @@ dispatcher.add_handler(MessageHandler(Filters.status_update.new_chat_members, de
 dispatcher.add_handler(MessageHandler(Filters.status_update.left_chat_member, delete_service_message, run_async=True))
 
 
+## Delete service messages
+def user_activity_accounting(update, context):
+        section = str(update.message.chat.id)
+        user_id = update.message.from_user.id
+        user_username = update.message.from_user.username
+        in_section = section in config.sections()
+        command_name = inspect.currentframe().f_code.co_name
+        feature_flag = config.get(section, command_name, fallback='off') == 'on'
+        if in_section and feature_flag:
+                db.activity_user(user_id, user_username)
+
+# Default handler for users activity accounting
+dispatcher.add_handler(MessageHandler(Filters.text, user_activity_accounting, run_async=True))
+
+
 ## Delete spam message and Ban spamer with admin button
 ### Disable until create integration with spam bot from JS developers
 # def delete_ban_button(update, context):


### PR DESCRIPTION
This is RFC, as i am not sure it is best approach.
This is first patch is to keep accounting of users messages (if bot have group privacy mode turned off). I am not sure i am doing it way you might like, so please suggest if i must implement it different way.

Next i am planning following to implement sort of very soft "votetoban".
After some logging to know who is active, we can enable optional feature that work as following:
On /report we check if user has activity in channel.
If user active - go on as before.

If it's user first message (most likely spammer, so he was not engaged in any conversation) AND we received more than one report on this message:
1)Forward message to admins channel with comment
2)Delete message in main group
3)Mute user
4)Send message to main group, with mentioning @username, that he is automatically muted and he can write to bot private to automatically appeal.

(Users have great satisfaction that they have some revenge on spammer)

So, to minimize possible harm:
1)Admins can notice wrong decision and unban user
2)User can unban himself, if he is human
