### PR TITLE
Optimize Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,27 @@
-FROM python:3.10.0b4-alpine
+FROM python:3.10-slim
 LABEL maintainer=Asgoret
 
-ARG user=bot
-ARG group=botGroup
+ARG APP_USER=bot
+ARG APP_GROUP=botgroup
+
+ENV APP_USER=${APP_USER}
+ENV APP_GROUP=${APP_GROUP}
 
 ENV botToken=mock
 ENV envFile=mock
 
-RUN addgroup -S ${group} && adduser -S ${user} -G ${group}; \
-    apk add --no-cache gcc g++ musl-dev python3-dev libffi-dev openssl-dev cargo                  
+RUN addgroup --system ${APP_GROUP} && adduser --system --ingroup ${APP_GROUP} ${APP_USER}
 
-USER ${user}
+USER ${APP_USER}
 
-WORKDIR /home/${user}
+WORKDIR /home/${APP_USER}
 COPY requirements.txt ./
 RUN mkdir ./bot; \
     pip install --upgrade pip; \
     pip install setuptools --upgrade; \
     pip install --no-cache-dir -r requirements.txt
-    
+
 COPY ./bot /bot
 WORKDIR /bot
 
-CMD python devopshelberbot.py -b=$botToken -e=$envFile
+CMD ["python", "devopshelberbot.py", "-b=$botToken", "-e=$envFile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,11 @@ ENV envFile=mock
 RUN addgroup --system ${APP_GROUP} && adduser --system --ingroup ${APP_GROUP} ${APP_USER}
 
 USER ${APP_USER}
-
 WORKDIR /home/${APP_USER}
+RUN mkdir ./bot
+
 COPY requirements.txt ./
-RUN mkdir ./bot; \
-    pip install --upgrade pip; \
-    pip install setuptools --upgrade; \
-    pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./bot /bot
 WORKDIR /bot

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-future>=0.16.0
-certifi
-tornado>=5.1
-cryptography>=3.4.7
-pysocks
-python-telegram-bot
+future==0.18.2
+certifi==2021.10.8
+tornado==6.1
+cryptography==36.0.1
+pysocks==1.7.1
+python-telegram-bot==13.10


### PR DESCRIPTION
Optimize docker image size by migrating to debian to avoid [compilation of extra libs under alpine](https://pythonspeed.com/articles/base-image-python-docker-images/):

```
local/devophelper_bot:alpine 1.14GB
local/devophelper_bot:debian 165MB
```

Also freeze Python dependencies versions to guarantee artifact is reproducible.