### PR TITLE
do not loss message entities while publishing

### DIFF
--- a/bot/devopshelberbot.py
+++ b/bot/devopshelberbot.py
@@ -167,9 +167,7 @@ class Base:
         matches_job = match_job.search(update.message.reply_to_message.text)
         matches_work = match_work.search(update.message.reply_to_message.text)
         rss_link = re.sub("@", "https://t.me/", job_channels[0])
-        msg = str(update.message.reply_to_message.text)
-        escTable = msg.maketrans(self.esc_map)
-        escMsg = msg.translate(escTable)
+        msg = update.message.reply_to_message.text_markdown_v2_urled
         user_id = update.message.reply_to_message.from_user.mention_markdown_v2()
         ChatUsername = str(update.message.chat.username)
         escTable = ChatUsername.maketrans(self.esc_map)
@@ -179,7 +177,7 @@ class Base:
             matches_work,
             rss_link,
             job_channels,
-            escMsg,
+            msg,
             user_id,
             escChatUsername,
         )


### PR DESCRIPTION
Check [text_markdown_v2_urled](https://python-telegram-bot.readthedocs.io/en/stable/telegram.message.html?highlight=urled#telegram.Message.text_markdown_v2_urled) method for details

Old code example result:
```python
>>> msg = str(msg.text)
>>> escTable = msg.maketrans(esc_map)
>>> escMsg = msg.translate(escTable)
>>> escMsg
'привет\\! Это сообщение \\- ссылка'
```

New code result on the same message:
```python
>>> msg = msg.text_markdown_v2_urled
>>> msg
'привет\\! Это сообщение \\- [ссылка](https://yandex.ru/)'
```